### PR TITLE
可拖拽调节界面尺寸，完善project table的create和remove功能

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4955,8 +4955,7 @@
     "colorette": {
       "version": "1.2.2",
       "resolved": "https://registry.npm.taobao.org/colorette/download/colorette-1.2.2.tgz?cache=0&sync_timestamp=1614259647923&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcolorette%2Fdownload%2Fcolorette-1.2.2.tgz",
-      "integrity": "sha1-y8x51emcrqLb8Q6zom/Ys+as+pQ=",
-      "dev": true
+      "integrity": "sha1-y8x51emcrqLb8Q6zom/Ys+as+pQ="
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -5868,8 +5867,7 @@
     "deepmerge": {
       "version": "4.2.2",
       "resolved": "https://registry.npm.taobao.org/deepmerge/download/deepmerge-4.2.2.tgz",
-      "integrity": "sha1-RNLqNnm49NT/ujPwPYZfwee/SVU=",
-      "dev": true
+      "integrity": "sha1-RNLqNnm49NT/ujPwPYZfwee/SVU="
     },
     "default-gateway": {
       "version": "5.0.5",
@@ -6530,8 +6528,7 @@
     "entities": {
       "version": "2.2.0",
       "resolved": "https://registry.npm.taobao.org/entities/download/entities-2.2.0.tgz?cache=0&sync_timestamp=1611535711703&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fentities%2Fdownload%2Fentities-2.2.0.tgz",
-      "integrity": "sha1-CY3JDruD2N/6CJ1VJWs1HTTE2lU=",
-      "dev": true
+      "integrity": "sha1-CY3JDruD2N/6CJ1VJWs1HTTE2lU="
     },
     "envinfo": {
       "version": "7.8.1",
@@ -10540,8 +10537,7 @@
     "klona": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.4.tgz",
-      "integrity": "sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA==",
-      "dev": true
+      "integrity": "sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA=="
     },
     "launch-editor": {
       "version": "2.2.1",
@@ -12070,6 +12066,11 @@
       "integrity": "sha1-9TdkAGlRaPTMaUrJOT0MlYXu6hk=",
       "dev": true
     },
+    "nanoid": {
+      "version": "3.1.23",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
+      "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw=="
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npm.taobao.org/nanomatch/download/nanomatch-1.2.13.tgz",
@@ -13132,6 +13133,11 @@
         "json-parse-even-better-errors": "^2.3.0",
         "lines-and-columns": "^1.1.6"
       }
+    },
+    "parse-srcset": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+      "integrity": "sha1-8r0iH2zJcKk42IVWq8WJyqqiveE="
     },
     "parse5": {
       "version": "4.0.0",
@@ -14927,6 +14933,86 @@
         }
       }
     },
+    "sanitize-html": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.4.0.tgz",
+      "integrity": "sha512-Y1OgkUiTPMqwZNRLPERSEi39iOebn2XJLbeiGOBhaJD/yLqtLGu6GE5w7evx177LeGgSE+4p4e107LMiydOf6A==",
+      "requires": {
+        "deepmerge": "^4.2.2",
+        "escape-string-regexp": "^4.0.0",
+        "htmlparser2": "^6.0.0",
+        "is-plain-object": "^5.0.0",
+        "klona": "^2.0.3",
+        "parse-srcset": "^1.0.2",
+        "postcss": "^8.0.2"
+      },
+      "dependencies": {
+        "dom-serializer": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
+          "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^4.2.0",
+            "entities": "^2.0.0"
+          }
+        },
+        "domelementtype": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+          "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
+        },
+        "domhandler": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.0.tgz",
+          "integrity": "sha512-zk7sgt970kzPks2Bf+dwT/PLzghLnsivb9CcxkvR8Mzr66Olr0Ofd8neSbglHJHaHa2MadfoSdNlKYAaafmWfA==",
+          "requires": {
+            "domelementtype": "^2.2.0"
+          }
+        },
+        "domutils": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.7.0.tgz",
+          "integrity": "sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==",
+          "requires": {
+            "dom-serializer": "^1.0.1",
+            "domelementtype": "^2.2.0",
+            "domhandler": "^4.2.0"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+        },
+        "htmlparser2": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
+          "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^4.0.0",
+            "domutils": "^2.5.2",
+            "entities": "^2.0.0"
+          }
+        },
+        "is-plain-object": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+          "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
+        },
+        "postcss": {
+          "version": "8.3.6",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.6.tgz",
+          "integrity": "sha512-wG1cc/JhRgdqB6WHEuyLTedf3KIRuD0hG6ldkFEZNCjRxiC+3i6kkWUUbiJQayP28iwG35cEmAbe98585BYV0A==",
+          "requires": {
+            "colorette": "^1.2.2",
+            "nanoid": "^3.1.23",
+            "source-map-js": "^0.6.2"
+          }
+        }
+      }
+    },
     "sass": {
       "version": "1.32.13",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.13.tgz",
@@ -15598,6 +15684,11 @@
       "resolved": "https://registry.npm.taobao.org/source-map/download/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
+    },
+    "source-map-js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
+      "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug=="
     },
     "source-map-resolve": {
       "version": "0.5.3",
@@ -17268,6 +17359,14 @@
       "version": "3.5.1",
       "resolved": "https://registry.nlark.com/vue-router/download/vue-router-3.5.1.tgz?cache=0&sync_timestamp=1620899536020&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fvue-router%2Fdownload%2Fvue-router-3.5.1.tgz",
       "integrity": "sha1-7fPPSQeVLR4Fg+B5I3Igxf9utsk="
+    },
+    "vue-sanitize": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/vue-sanitize/-/vue-sanitize-0.2.1.tgz",
+      "integrity": "sha512-MhrfAaAqIQ8JXWfdlhK6f+H2WnZ7KQwkOgLNeUyfACI2bq/3HPZ2zeUQDathnLdsXMXAa8pJehOgPYtlaG9Jew==",
+      "requires": {
+        "sanitize-html": "^2.1.1"
+      }
     },
     "vue-style-loader": {
       "version": "4.1.3",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "vue-apollo": "^3.0.7",
     "vue-i18n": "^8.25.0",
     "vue-router": "^3.2.0",
+    "vue-sanitize": "^0.2.1",
     "vuetify": "^2.4.0"
   },
   "devDependencies": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -43,9 +43,6 @@ export default {
       this.users = users;
     },
   },
-  mounted() {
-    console.log(this.project);
-  },
 };
 </script>
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,10 +1,10 @@
 <template>
   <v-app>
-    <IndexHeader v-if="this.$route.path === '/'" />
+    <IndexHeader v-if="this.$route.path === '/'" v-bind:projects="project" />
     <EditorHeader v-else />
     <v-main>
       <!-- force refresh the page when at the same route -->
-      <router-view :key="$route.fullPath"></router-view>
+      <router-view :key="$route.fullPath" :projects="project"></router-view>
     </v-main>
   </v-app>
 </template>
@@ -12,9 +12,18 @@
 <script>
 import IndexHeader from './components/IndexHeader.vue';
 import EditorHeader from './components/EditorHeader.vue';
+import { GET_PROJECT } from './query';
 
 export default {
   name: 'App',
+  data() {
+    return {
+      project: [],
+    };
+  },
+  apollo: {
+    project: GET_PROJECT,
+  },
   components: {
     IndexHeader,
     EditorHeader,

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,7 @@
 <template>
   <v-app>
-    <IndexHeader v-if="this.$route.path === '/'" v-bind:projects="project" />
-    <EditorHeader v-else />
+    <IndexHeader v-if="this.$route.path === '/'" :projects="project" />
+    <EditorHeader v-else :projects="project" />
     <v-main>
       <!-- force refresh the page when at the same route -->
       <router-view :key="$route.fullPath" :projects="project"></router-view>

--- a/src/components/EditorHeader.vue
+++ b/src/components/EditorHeader.vue
@@ -192,7 +192,7 @@ export default {
     },
   },
   mounted() {
-    // fetch current project info using hash from url
+    // fetch current project info using _id from url
     this.$apollo
       .query({
         query: GET_PROJECT,

--- a/src/components/EditorHeader.vue
+++ b/src/components/EditorHeader.vue
@@ -20,7 +20,8 @@
       <div class="projects-container">
         <v-row>
           <v-col cols="3" v-for="(item, index) in projects" :key="index">
-            <a :href="sanitizeURL(item.hash)"><div class="project"></div></a>
+            <!-- {{ sanitize(item.hash) }} -->
+            <a :href="$sanitize(item.hash)"><div class="project"></div></a>
             <p>{{ item.projectName }}</p>
           </v-col>
 
@@ -182,9 +183,6 @@ export default {
     copyURL() {
       navigator.clipboard.writeText(this.url);
       this.copied = true;
-    },
-    sanitizeURL(url) {
-      return this.$sanitize(url);
     },
   },
   mounted() {

--- a/src/components/EditorHeader.vue
+++ b/src/components/EditorHeader.vue
@@ -11,7 +11,7 @@
     >
       <template v-slot:activator="{ on, attrs }">
         <h4 class="white--text" v-bind="attrs" v-on="on">
-          Project Name <v-icon v-if="projectMenu" color="white" class="mb-1">mdi-chevron-up</v-icon>
+          {{ project.projectName }} <v-icon v-if="projectMenu" color="white" class="mb-1">mdi-chevron-up</v-icon>
           <v-icon v-else color="white" class="mb-1">mdi-chevron-down</v-icon>
         </h4>
       </template>
@@ -150,12 +150,14 @@
 
 <script>
 import UserStatus from './UserStatus.vue';
+import { GET_PROJECT } from '../query';
 
 export default {
   components: {
     UserStatus,
   },
   data: () => ({
+    project: [],
     projectMenu: false,
     users: [
       { id: '02', userName: 'Mark', userAvatar: 'avatar2', isOnline: true, isEditing: false },
@@ -192,6 +194,18 @@ export default {
     },
   },
   mounted() {
+    // fetch current project info using hash from url
+    this.$apollo
+      .query({
+        query: GET_PROJECT,
+        variables: {
+          hash: this.$route.fullPath.replace('/', ''),
+        },
+      })
+      .then((res) => {
+        [this.project] = res.data.project;
+      });
+
     this.url += this.$route.fullPath;
     // watch the width of the window
     const that = this;

--- a/src/components/EditorHeader.vue
+++ b/src/components/EditorHeader.vue
@@ -20,7 +20,7 @@
       <div class="projects-container">
         <v-row>
           <v-col cols="3" v-for="(item, index) in projects" :key="index">
-            <a :href="item._id"><div class="project"></div> </a>
+            <a :href="item.hash"><div class="project"></div> </a>
             <p>{{ item.projectName }}</p>
           </v-col>
 

--- a/src/components/EditorHeader.vue
+++ b/src/components/EditorHeader.vue
@@ -191,7 +191,7 @@ export default {
       .query({
         query: GET_PROJECT,
         variables: {
-          _id: this.$route.fullPath.replace('/', ''),
+          hash: this.$route.fullPath.replace('/', ''),
         },
       })
       .then((res) => {

--- a/src/components/EditorHeader.vue
+++ b/src/components/EditorHeader.vue
@@ -20,7 +20,7 @@
       <div class="projects-container">
         <v-row>
           <v-col cols="3" v-for="(item, index) in projects" :key="index">
-            <a :href="item.hash"><div class="project"></div> </a>
+            <a :href="sanitizeURL(item.hash)"><div class="project"></div></a>
             <p>{{ item.projectName }}</p>
           </v-col>
 
@@ -161,7 +161,6 @@ export default {
     users: Array,
     projects: Array,
   },
-
   data() {
     return {
       project: [],
@@ -183,6 +182,9 @@ export default {
     copyURL() {
       navigator.clipboard.writeText(this.url);
       this.copied = true;
+    },
+    sanitizeURL(url) {
+      return this.$sanitize(url);
     },
   },
   mounted() {

--- a/src/components/EditorHeader.vue
+++ b/src/components/EditorHeader.vue
@@ -17,14 +17,9 @@
       </template>
       <div class="projects-container">
         <v-row>
-          <v-col cols="3">
-            <div class="project"></div>
-            <p>Project 1</p>
-          </v-col>
-
-          <v-col cols="3">
-            <div class="project"></div>
-            <p>Project 2</p>
+          <v-col cols="3" v-for="(item, index) in projects" :key="index">
+            <a :href="item._id"><div class="project"></div> </a>
+            <p>{{ item.projectName }}</p>
           </v-col>
 
           <v-col cols="3">
@@ -156,6 +151,7 @@ export default {
   components: {
     UserStatus,
   },
+  props: ['projects'],
   data: () => ({
     project: [],
     projectMenu: false,
@@ -199,7 +195,7 @@ export default {
       .query({
         query: GET_PROJECT,
         variables: {
-          id: this.$route.fullPath.replace('/', ''),
+          _id: this.$route.fullPath.replace('/', ''),
         },
       })
       .then((res) => {

--- a/src/components/EditorHeader.vue
+++ b/src/components/EditorHeader.vue
@@ -1,6 +1,8 @@
 <template>
   <v-app-bar app color="primary">
-    <v-toolbar-title class="white--text mr-5">正大集团</v-toolbar-title>
+    <v-toolbar-title class="mr-5">
+      <router-link to="/" class="white--text" style="text-decoration: none">正大集团</router-link>
+    </v-toolbar-title>
     <v-menu
       offset-y
       min-height

--- a/src/components/EditorHeader.vue
+++ b/src/components/EditorHeader.vue
@@ -199,7 +199,7 @@ export default {
       .query({
         query: GET_PROJECT,
         variables: {
-          hash: this.$route.fullPath.replace('/', ''),
+          id: this.$route.fullPath.replace('/', ''),
         },
       })
       .then((res) => {

--- a/src/components/EditorHeader.vue
+++ b/src/components/EditorHeader.vue
@@ -20,7 +20,6 @@
       <div class="projects-container">
         <v-row>
           <v-col cols="3" v-for="(item, index) in projects" :key="index">
-            <!-- {{ sanitize(item.hash) }} -->
             <a :href="$sanitize(item.hash)"><div class="project"></div></a>
             <p>{{ item.projectName }}</p>
           </v-col>

--- a/src/components/EditorToolbar.vue
+++ b/src/components/EditorToolbar.vue
@@ -167,6 +167,7 @@ export default {
       userName: '',
       userAvatar: '',
     },
+    projects: Array,
   },
   data() {
     return {

--- a/src/components/EditorToolbar.vue
+++ b/src/components/EditorToolbar.vue
@@ -52,6 +52,17 @@
           <div :is="tool.menu" />
         </v-menu>
 
+        <v-tooltip nudge-right="10" left>
+          <template v-slot:activator="{ on, tooltip }">
+            <v-list-item v-bind="tooltip" v-on="on" @click="$emit('download')">
+              <v-list-item-content>
+                <v-icon color="greyBtn">mdi-download</v-icon>
+              </v-list-item-content>
+            </v-list-item>
+          </template>
+          <span>{{ $t('tools.download.name') }}</span>
+        </v-tooltip>
+
         <v-divider color="#737d81" class="toolbar-divider"></v-divider>
 
         <v-menu
@@ -168,6 +179,7 @@ export default {
       userAvatar: '',
     },
     projects: Array,
+    downloadCode: { type: Function },
   },
   data() {
     return {
@@ -175,7 +187,6 @@ export default {
         { icon: 'mdi-cog', tooltip: 'tools.setting.name', menu: Setting },
         { icon: 'mdi-magnify', tooltip: 'tools.search.name', menu: Setting },
         { icon: 'mdi-history', tooltip: 'tools.history.name', menu: History },
-        { icon: 'mdi-download', tooltip: 'tools.download.name', menu: Setting },
       ],
       userName: '',
       userAvatar: '',
@@ -192,6 +203,7 @@ export default {
   created() {
     this.userName = storage.getUserInfo().userName;
     this.userAvatar = storage.getUserInfo().userAvatar;
+    this.$emit('download');
   },
   computed: {
     getUserAvatar() {

--- a/src/components/EditorToolbar.vue
+++ b/src/components/EditorToolbar.vue
@@ -46,7 +46,7 @@
                   </v-list-item-content>
                 </v-list-item>
               </template>
-              <span>{{ tool.tooltip }}</span>
+              <span>{{ $t(tool.tooltip) }}</span>
             </v-tooltip>
           </template>
           <div :is="tool.menu" />
@@ -71,7 +71,7 @@
                   </v-list-item-content>
                 </v-list-item>
               </template>
-              <span>Something</span>
+              <span>{{ $t('tools.video.name') }}</span>
             </v-tooltip>
           </template>
           <Setting />
@@ -98,7 +98,7 @@
                   </v-list-item-content>
                 </v-list-item>
               </template>
-              <span>Information</span>
+              <span>{{ $t('tools.information.name') }}</span>
             </v-tooltip>
           </template>
           <Setting />
@@ -171,15 +171,25 @@ export default {
   data() {
     return {
       tools: [
-        { icon: 'mdi-cog', tooltip: 'Settiing', menu: Setting },
-        { icon: 'mdi-magnify', tooltip: 'Search', menu: Setting },
-        { icon: 'mdi-history', tooltip: 'History', menu: History },
-        { icon: 'mdi-download', tooltip: 'Download', menu: Setting },
+        { icon: 'mdi-cog', tooltip: 'tools.setting.name', menu: Setting },
+        { icon: 'mdi-magnify', tooltip: 'tools.search.name', menu: Setting },
+        { icon: 'mdi-history', tooltip: 'tools.history.name', menu: History },
+        { icon: 'mdi-download', tooltip: 'tools.download.name', menu: Setting },
       ],
       userName: '',
       userAvatar: '',
     };
   },
+  // computed: {
+  //   tools() {
+  //     return [
+  //       { icon: 'mdi-cog', tooltip: this.$t('tools.setting.name'), menu: Setting },
+  //       { icon: 'mdi-magnify', tooltip: this.$t('tools.search.name'), menu: Setting },
+  //       { icon: 'mdi-history', tooltip: this.$t('tools.history.name'), menu: History },
+  //       { icon: 'mdi-download', tooltip: this.$t('tools.download.name'), menu: Setting },
+  //     ];
+  //   },
+  // },
   created() {
     this.userName = storage.getUserInfo().userName;
     this.userAvatar = storage.getUserInfo().userAvatar;

--- a/src/components/EditorToolbar.vue
+++ b/src/components/EditorToolbar.vue
@@ -22,10 +22,33 @@
               <span>Help</span>
             </v-tooltip>
           </template>
-          <Setting />
+          <!-- help component here -->
         </v-menu>
 
         <v-divider color="#737d81" class="toolbar-divider"></v-divider>
+
+        <v-menu
+          left
+          offset-x
+          :close-on-content-click="false"
+          content-class="elevation-0 tool-menu"
+          z-index="1"
+          rounded="0"
+        >
+          <template v-slot:activator="{ on: menu, attrs }" class="tool-menu">
+            <v-tooltip nudge-right="10" left>
+              <template v-slot:activator="{ on: tooltip }">
+                <v-list-item v-bind="attrs" v-on="{ ...tooltip, ...menu }">
+                  <v-list-item-content>
+                    <v-icon color="greyBtn">mdi-cog</v-icon>
+                  </v-list-item-content>
+                </v-list-item>
+              </template>
+              <span>Setting</span>
+            </v-tooltip>
+          </template>
+          <Setting v-on="$listeners" />
+        </v-menu>
 
         <v-menu
           v-for="tool in tools"
@@ -85,7 +108,7 @@
               <span>{{ $t('tools.video.name') }}</span>
             </v-tooltip>
           </template>
-          <Setting />
+          <!-- video component here -->
         </v-menu>
       </div>
 
@@ -112,7 +135,7 @@
               <span>{{ $t('tools.information.name') }}</span>
             </v-tooltip>
           </template>
-          <Setting />
+          <!-- information component here -->
         </v-menu>
 
         <v-menu
@@ -184,7 +207,6 @@ export default {
   data() {
     return {
       tools: [
-        { icon: 'mdi-cog', tooltip: 'tools.setting.name', menu: Setting },
         { icon: 'mdi-magnify', tooltip: 'tools.search.name', menu: Setting },
         { icon: 'mdi-history', tooltip: 'tools.history.name', menu: History },
       ],

--- a/src/components/EditorToolbar.vue
+++ b/src/components/EditorToolbar.vue
@@ -180,16 +180,6 @@ export default {
       userAvatar: '',
     };
   },
-  // computed: {
-  //   tools() {
-  //     return [
-  //       { icon: 'mdi-cog', tooltip: this.$t('tools.setting.name'), menu: Setting },
-  //       { icon: 'mdi-magnify', tooltip: this.$t('tools.search.name'), menu: Setting },
-  //       { icon: 'mdi-history', tooltip: this.$t('tools.history.name'), menu: History },
-  //       { icon: 'mdi-download', tooltip: this.$t('tools.download.name'), menu: Setting },
-  //     ];
-  //   },
-  // },
   created() {
     this.userName = storage.getUserInfo().userName;
     this.userAvatar = storage.getUserInfo().userAvatar;

--- a/src/components/IndexHeader.vue
+++ b/src/components/IndexHeader.vue
@@ -28,7 +28,6 @@
                   item-text="langName"
                   :rules="syntaxRules"
                 ></v-select>
-                <!-- <v-text-field v-model="projectSyntax" label="Project syntax" :rules="nameRules" required></v-text-field> -->
               </v-col>
             </v-row>
           </v-container>

--- a/src/components/IndexHeader.vue
+++ b/src/components/IndexHeader.vue
@@ -50,6 +50,8 @@ import { storage } from '../util';
 import { CREATE_PROJECT } from '../query';
 
 export default {
+  name: 'IndexHeader',
+  props: ['projects'],
   data() {
     return {
       valid: false,
@@ -83,7 +85,9 @@ export default {
             userId: storage.getUserInfo().userID,
           },
         })
-        .then(() => {});
+        .then((res) => {
+          this.projects.push(res.data.createProject.data[0]);
+        });
     },
   },
 };

--- a/src/components/IndexHeader.vue
+++ b/src/components/IndexHeader.vue
@@ -83,9 +83,7 @@ export default {
             userId: storage.getUserInfo().userID,
           },
         })
-        .then((res) => {
-          console.log(res);
-        });
+        .then(() => {});
     },
   },
 };

--- a/src/components/IndexHeader.vue
+++ b/src/components/IndexHeader.vue
@@ -21,7 +21,14 @@
               </v-col>
 
               <v-col cols="12" md="4">
-                <v-text-field v-model="projectSyntax" label="Project syntax" :rules="nameRules" required></v-text-field>
+                <v-select
+                  v-model="projectSyntax"
+                  :items="codeLanguageList"
+                  label="Project syntax"
+                  item-text="langName"
+                  :rules="syntaxRules"
+                ></v-select>
+                <!-- <v-text-field v-model="projectSyntax" label="Project syntax" :rules="nameRules" required></v-text-field> -->
               </v-col>
             </v-row>
           </v-container>
@@ -46,6 +53,7 @@
 </template>
 
 <script>
+import CODE_LANGUAGE_LIST from '../map';
 import { storage } from '../util';
 import { CREATE_PROJECT } from '../query';
 
@@ -57,8 +65,10 @@ export default {
       valid: false,
       projectName: '',
       nameRules: [(v) => !!v || 'Name is required'],
+      syntaxRules: [(v) => !!v || 'Syntax is required'],
       projectSyntax: '',
       dialog: false,
+      codeLanguageList: CODE_LANGUAGE_LIST,
     };
   },
   methods: {

--- a/src/components/IndexToolbar.vue
+++ b/src/components/IndexToolbar.vue
@@ -21,7 +21,7 @@
                   </v-list-item-content>
                 </v-list-item>
               </template>
-              <span>Information</span>
+              <span>{{ $t('tools.information.name') }}</span>
             </v-tooltip>
           </template>
           <Setting />

--- a/src/components/tools/Setting.vue
+++ b/src/components/tools/Setting.vue
@@ -70,9 +70,4 @@ export default {
   min-width: 240px;
   max-width: 400px;
 }
-
-.v-list {
-  /* background: #2C333B;
-  color: white; */
-}
 </style>

--- a/src/components/tools/Setting.vue
+++ b/src/components/tools/Setting.vue
@@ -18,16 +18,19 @@
       <div>
         <h5>Syntax</h5>
         <v-select
+          v-model="selectedLanguage"
           :items="codeLanguageList"
           item-text="langName"
-          item-langValue="abbr"
+          item-value="langValue"
           dark
           outlined
           dense
+          return-object
           color="blueBtn"
           background-color="primary lighten-1"
           item-color="blueBtn"
           :menu-props="{ bottom: true, offsetY: true }"
+          @change="$emit('changeLanguage', `${selectedLanguage.langValue}`)"
         ></v-select>
       </div>
 
@@ -54,6 +57,7 @@ export default {
   name: 'Setting',
   data() {
     return {
+      selectedLanguage: '',
       codeLanguageList: CODE_LANGUAGE_LIST,
       tabSize: [2, 4, 6],
     };

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -29,6 +29,21 @@
       "syntax": "Syntax",
       "tabSize": "Tab Size"
     },
+    "search": {
+      "name": "Search"
+    },
+    "history": {
+      "name": "History"
+    },
+    "download": {
+      "name": "Download"
+    },
+    "information": {
+      "name": "Information"
+    },
+    "video": {
+      "name": "Video"
+    },
     "profile": {
       "userProfile": "User Profile",
       "change": "change",

--- a/src/lang/zh-CN.json
+++ b/src/lang/zh-CN.json
@@ -29,6 +29,21 @@
       "syntax": "语言",
       "tabSize": "tab长度"
     },
+    "search": {
+      "name": "搜索"
+    },
+    "history": {
+      "name": "历史"
+    },
+    "download": {
+      "name": "下载"
+    },
+    "information": {
+      "name": "信息"
+    },
+    "video": {
+      "name": "视频"
+    },
     "profile": {
       "userProfile": "个人信息",
       "change": "上传",

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,7 @@
 import Vue from 'vue';
 import ApolloClient from 'apollo-boost';
 import VueApollo from 'vue-apollo';
+import VueSanitize from 'vue-sanitize';
 import App from './App.vue';
 import './registerServiceWorker';
 import router from './router';
@@ -16,6 +17,7 @@ const apolloProvider = new VueApollo({
 });
 
 Vue.use(VueApollo);
+Vue.use(VueSanitize);
 
 new Vue({
   router,

--- a/src/query.js
+++ b/src/query.js
@@ -25,6 +25,8 @@ export const CREATE_PROJECT = gql`
         hash
         projectName
         syntax
+        createTime
+        updateTime
       }
     }
   }

--- a/src/query.js
+++ b/src/query.js
@@ -24,13 +24,16 @@ export const CREATE_PROJECT = gql`
         _id
         hash
         projectName
-        code
-        createTime
-        updateTime
         syntax
-        createUser
-        lastModifiedUser
       }
+    }
+  }
+`;
+
+export const UPDATE_PROJECT = gql`
+  mutation ($id: String!, $isTop: Boolean) {
+    createProject(id: $id, isTop: $isTop) {
+      success
     }
   }
 `;

--- a/src/views/Editor.vue
+++ b/src/views/Editor.vue
@@ -263,7 +263,6 @@ export default {
           } else if (this.sectionWidth > window.innerWidth * 0.8) {
             this.sectionWidth = window.innerWidth * 0.8;
           }
-          console.log(this.sectionWidth);
         };
         document.onmouseup = () => {
           // color restoration

--- a/src/views/Editor.vue
+++ b/src/views/Editor.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="fill-height row-container">
-    <div class="left" v-bind:style="{ width: sectionWidth + 'px' }"></div>
+    <div class="history-section" v-bind:style="{ width: sectionWidth + 'px' }"></div>
     <div class="resize-bar" ref="resizeBar"></div>
-    <div class="middle" v-bind:style="{ width: 'calc(100% - ' + sectionWidth + 'px - 75px)' }">
+    <div class="editor-section" v-bind:style="{ width: 'calc(100% - ' + sectionWidth + 'px - 75px)' }">
       <div class="editor-container">
         <div class="title-block">
           <div class="title-text">Editor</div>
@@ -34,7 +34,7 @@
       </div>
     </div>
 
-    <div class="right">
+    <div class="toolbar-section">
       <EditorToolbar v-bind="$attrs" v-on="$listeners" />
     </div>
   </div>
@@ -354,7 +354,7 @@ export default {
   align-items: stretch;
   overflow: hidden;
   position: relative;
-  .left {
+  .history-section {
     border-top: 1px solid #eee;
     background-color: #3d4b56;
     position: relative;
@@ -368,13 +368,13 @@ export default {
     width: 5px;
     cursor: col-resize;
   }
-  .middle {
+  .editor-section {
     border-top: 1px solid #eee;
     border-left: 1px solid #eee;
     background-color: #2c333b;
   }
 
-  .right {
+  .toolbar-section {
     width: 75px;
   }
 }

--- a/src/views/Editor.vue
+++ b/src/views/Editor.vue
@@ -35,7 +35,7 @@
     </div>
 
     <div class="toolbar-section">
-      <EditorToolbar v-bind="$attrs" v-on="$listeners" />
+      <EditorToolbar v-bind="$attrs" v-on="$listeners" @download="downloadCode" />
     </div>
   </div>
 </template>

--- a/src/views/Editor.vue
+++ b/src/views/Editor.vue
@@ -47,6 +47,7 @@ import { getCodeInLocalDb, updateCodeInLocalDb } from '../indexedDb';
 import { formattedDateTime, storage } from '../util';
 import CODE_LANGUAGE_LIST from '../map';
 import EditorToolbar from '../components/EditorToolbar.vue';
+// import { GET_PROJECT } from '../query';
 
 export default {
   name: 'Editor',
@@ -69,6 +70,7 @@ export default {
       codeLanguageList: CODE_LANGUAGE_LIST,
       users: [],
       sectionWidth: 300,
+      // project: [],
     };
   },
   methods: {
@@ -88,7 +90,6 @@ export default {
         minimap: {
           enabled: false,
         },
-        automaticLayout: true,
       });
     },
     initSocketIO() {
@@ -227,9 +228,18 @@ export default {
     this.editorEventHandler();
 
     this.resizeBarController();
-  },
-  beforeDestroy() {
-    this.editor.dispose();
+
+    // fetch current project info using hash from url
+    // this.$apollo
+    //   .query({
+    //     query: GET_PROJECT,
+    //     variables: {
+    //       hash: this.$route.fullPath.replace('/', ''),
+    //     },
+    //   })
+    //   .then((res) => {
+    //     [this.project] = res.data.project;
+    //   });
   },
 };
 </script>

--- a/src/views/Editor.vue
+++ b/src/views/Editor.vue
@@ -47,7 +47,6 @@ import { getCodeInLocalDb, updateCodeInLocalDb } from '../indexedDb';
 import { formattedDateTime, storage } from '../util';
 import CODE_LANGUAGE_LIST from '../map';
 import EditorToolbar from '../components/EditorToolbar.vue';
-// import { GET_PROJECT } from '../query';
 
 export default {
   name: 'Editor',
@@ -70,7 +69,6 @@ export default {
       codeLanguageList: CODE_LANGUAGE_LIST,
       users: [],
       sectionWidth: 300,
-      // project: [],
     };
   },
   methods: {
@@ -94,6 +92,7 @@ export default {
     },
     initSocketIO() {
       this.projectId = this.$route.params.projectId;
+      console.log(this.projectId);
 
       const socketUrl = process.env.NODE_ENV === 'test' ? '' : 'ws://localhost:3000';
       this.socket = io(socketUrl, { transports: ['websocket'] });
@@ -228,18 +227,6 @@ export default {
     this.editorEventHandler();
 
     this.resizeBarController();
-
-    // fetch current project info using hash from url
-    // this.$apollo
-    //   .query({
-    //     query: GET_PROJECT,
-    //     variables: {
-    //       hash: this.$route.fullPath.replace('/', ''),
-    //     },
-    //   })
-    //   .then((res) => {
-    //     [this.project] = res.data.project;
-    //   });
   },
 };
 </script>

--- a/src/views/Editor.vue
+++ b/src/views/Editor.vue
@@ -1,7 +1,8 @@
 <template>
-  <v-row no-gutters d-flex class="fill-height">
-    <v-col class="left"> </v-col>
-    <v-col cols="8" class="middle">
+  <div class="fill-height row-container">
+    <div class="left" v-bind:style="{ width: sectionWidth + 'px' }"></div>
+    <div class="resize-bar" ref="resizeBar"></div>
+    <div class="middle">
       <div class="editor-container">
         <div class="title-block">
           <div class="title-text">Editor</div>
@@ -31,12 +32,12 @@
           </p>
         </div>
       </div>
-    </v-col>
+    </div>
 
-    <v-col cols="1" class="right">
+    <div class="right">
       <EditorToolbar />
-    </v-col>
-  </v-row>
+    </div>
+  </div>
 </template>
 
 <script>
@@ -67,6 +68,7 @@ export default {
       selectedCodeLanguage: 'javascript',
       codeLanguageList: CODE_LANGUAGE_LIST,
       users: [],
+      sectionWidth: 300,
     };
   },
   methods: {
@@ -193,12 +195,38 @@ export default {
         this.setCode(code);
       });
     },
+
+    resizeBarController() {
+      const resize = this.$refs.resizeBar;
+      resize.onmousedown = (e) => {
+        // Color change reminder
+        resize.style.background = '#818181';
+        let startX = e.clientX;
+        resize.left = resize.offsetLeft;
+        document.onmousemove = (ex) => {
+          // Calculate and apply displacement
+          const endX = ex.clientX;
+          const moveLen = endX - startX;
+          startX = endX;
+          this.sectionWidth += moveLen;
+        };
+        document.onmouseup = () => {
+          // color restoration
+          resize.style.background = '';
+          document.onmousemove = null;
+          document.onmouseup = null;
+        };
+        return false;
+      };
+    },
   },
   mounted() {
     this.initEditor();
     this.initSocketIO();
     this.consoleHandler();
     this.editorEventHandler();
+
+    this.resizeBarController();
   },
   beforeDestroy() {
     this.editor.dispose();
@@ -211,7 +239,7 @@ export default {
   display: flex;
   flex-direction: column;
   height: 88vh;
-  width: 100%;
+  width: inherit;
 }
 
 .title-block {
@@ -261,19 +289,37 @@ export default {
   }
 }
 
-.left {
-  border-top: 1px solid #eee;
-  background-color: #3d4b56;
-}
+.row-container {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  align-items: stretch;
+  overflow: hidden;
+  position: relative;
+  .left {
+    max-width: 55%;
+    border-top: 1px solid #eee;
+    background-color: #3d4b56;
+    position: relative;
+  }
+  .resize-bar {
+    border-top: 1px solid #eee;
+    background-color: black;
+    height: 100%;
+    top: 0;
+    right: 0;
+    width: 5px;
+    cursor: col-resize;
+  }
+  .middle {
+    flex: 1 0 auto;
+    border-top: 1px solid #eee;
+    border-left: 1px solid #eee;
+    background-color: #2c333b;
+  }
 
-.middle {
-  border-top: 1px solid #eee;
-  border-left: 1px solid #eee;
-  background-color: #2c333b;
-}
-
-.right {
-  min-width: 75px;
-  max-width: 100px;
+  .right {
+    width: 75px;
+  }
 }
 </style>

--- a/src/views/Editor.vue
+++ b/src/views/Editor.vue
@@ -35,7 +35,12 @@
     </div>
 
     <div class="toolbar-section">
-      <EditorToolbar v-bind="$attrs" v-on="$listeners" @download="downloadCode" />
+      <EditorToolbar
+        v-bind="$attrs"
+        v-on="$listeners"
+        @download="downloadCode"
+        @changeLanguage="onCodeLanguageChange"
+      />
     </div>
   </div>
 </template>
@@ -230,12 +235,14 @@ export default {
       downloadElement.download = `code-${formattedDateTime(new Date())}`;
       downloadElement.click();
     },
-    onCodeLanguageChange() {
+    onCodeLanguageChange(value) {
       if (this.selectedCodeLanguage === 'javascript') {
         this.consoleVisible = true;
       } else {
         this.consoleVisible = false;
       }
+      this.selectedCodeLanguage = value;
+      console.log(this.selectedCodeLanguage);
       this.$nextTick(() => {
         const code = this.getCode();
         this.editor.dispose();
@@ -243,7 +250,6 @@ export default {
         this.setCode(code);
       });
     },
-
     resizeBarController() {
       const resize = this.$refs.resizeBar;
       resize.onmousedown = (e) => {

--- a/src/views/Editor.vue
+++ b/src/views/Editor.vue
@@ -2,7 +2,7 @@
   <div class="fill-height row-container">
     <div class="left" v-bind:style="{ width: sectionWidth + 'px' }"></div>
     <div class="resize-bar" ref="resizeBar"></div>
-    <div class="middle">
+    <div class="middle" v-bind:style="{ width: 'calc(100% - ' + sectionWidth + 'px - 75px)' }">
       <div class="editor-container">
         <div class="title-block">
           <div class="title-text">Editor</div>
@@ -17,7 +17,7 @@
           </div>
         </div>
         <div ref="editor" class="editor"></div>
-        <div v-show="consoleVisible" class="title-block">
+        <!-- <div v-show="consoleVisible" class="title-block">
           <div class="title-text">Console</div>
           <div class="button-block">
             <button class="title-button" @click="runCode">Run</button>
@@ -30,7 +30,7 @@
             {{ item.style === 'error' ? '&#215;' : '' }}
             {{ item.msg }}
           </p>
-        </div>
+        </div> -->
       </div>
     </div>
 
@@ -92,6 +92,7 @@ export default {
         minimap: {
           enabled: false,
         },
+        automaticLayout: true,
       });
     },
     initSocketIO() {
@@ -256,6 +257,13 @@ export default {
           const moveLen = endX - startX;
           startX = endX;
           this.sectionWidth += moveLen;
+
+          if (this.sectionWidth < 0) {
+            this.sectionWidth = 0;
+          } else if (this.sectionWidth > window.innerWidth * 0.8) {
+            this.sectionWidth = window.innerWidth * 0.8;
+          }
+          console.log(this.sectionWidth);
         };
         document.onmouseup = () => {
           // color restoration
@@ -273,7 +281,7 @@ export default {
   mounted() {
     this.initEditor();
     this.initSocketIO();
-    this.consoleHandler();
+    // this.consoleHandler();
     this.editorEventHandler();
 
     this.resizeBarController();
@@ -289,7 +297,7 @@ export default {
   display: flex;
   flex-direction: column;
   height: 88vh;
-  width: inherit;
+  width: 100%;
 }
 
 .title-block {
@@ -347,7 +355,6 @@ export default {
   overflow: hidden;
   position: relative;
   .left {
-    max-width: 55%;
     border-top: 1px solid #eee;
     background-color: #3d4b56;
     position: relative;
@@ -362,7 +369,6 @@ export default {
     cursor: col-resize;
   }
   .middle {
-    flex: 1 0 auto;
     border-top: 1px solid #eee;
     border-left: 1px solid #eee;
     background-color: #2c333b;

--- a/src/views/Editor.vue
+++ b/src/views/Editor.vue
@@ -227,6 +227,9 @@ export default {
 
     this.resizeBarController();
   },
+  beforeDestroy() {
+    this.editor.dispose();
+  },
 };
 </script>
 

--- a/src/views/Editor.vue
+++ b/src/views/Editor.vue
@@ -17,20 +17,6 @@
           </div>
         </div>
         <div ref="editor" class="editor"></div>
-        <!-- <div v-show="consoleVisible" class="title-block">
-          <div class="title-text">Console</div>
-          <div class="button-block">
-            <button class="title-button" @click="runCode">Run</button>
-            <button class="title-button" @click="clearConsole">Clear</button>
-          </div>
-        </div>
-        <div v-show="consoleVisible" class="console">
-          <p v-for="item in logList" class="log-item" :key="item.index" :class="item.style">
-            {{ item.style === 'warn' ? '&#9888;' : '' }}
-            {{ item.style === 'error' ? '&#215;' : '' }}
-            {{ item.msg }}
-          </p>
-        </div> -->
       </div>
     </div>
 
@@ -65,7 +51,6 @@ export default {
     return {
       editor: null,
       socket: null,
-      consoleVisible: true,
       logStyle: '',
       logList: [],
       codeUpdateEnable: true, // Debounce for real-time sync
@@ -194,40 +179,14 @@ export default {
         }, 1000);
       });
     },
-    consoleHandler() {
-      console.original = { ...console };
-      console.log = (msg) => {
-        this.addLog(msg);
-      };
-      console.info = (msg) => {
-        this.addLog(msg);
-      };
-      console.warn = (msg) => {
-        this.addLog(msg, 'warn');
-      };
-      console.error = (msg) => {
-        this.addLog(msg, 'error');
-      };
-    },
     setCode(code) {
       this.editor.setValue(code);
     },
     getCode() {
       return this.editor.getValue();
     },
-    runCode() {
-      try {
-        // eslint-disable-next-line no-new-func
-        Function(this.getCode())();
-      } catch (err) {
-        console.error(err.toString());
-      }
-    },
     addLog(msg, style) {
       this.logList.push({ msg, style });
-    },
-    clearConsole() {
-      this.logList = [];
     },
     downloadCode() {
       const blob = new Blob([this.getCode()], { type: 'text' });
@@ -238,11 +197,6 @@ export default {
       downloadElement.click();
     },
     onCodeLanguageChange(value) {
-      // if (this.selectedCodeLanguage === 'javascript') {
-      //   this.consoleVisible = true;
-      // } else {
-      //   this.consoleVisible = false;
-      // }
       this.syntax = value;
       this.selectedCodeLanguage = value;
       this.$nextTick(() => {
@@ -288,9 +242,7 @@ export default {
   mounted() {
     this.initEditor();
     this.initSocketIO();
-    // this.consoleHandler();
     this.editorEventHandler();
-
     this.resizeBarController();
   },
   beforeDestroy() {

--- a/src/views/Editor.vue
+++ b/src/views/Editor.vue
@@ -92,7 +92,6 @@ export default {
     },
     initSocketIO() {
       this.projectId = this.$route.params.projectId;
-      console.log(this.projectId);
 
       const socketUrl = process.env.NODE_ENV === 'test' ? '' : 'ws://localhost:3000';
       this.socket = io(socketUrl, { transports: ['websocket'] });

--- a/src/views/Projects.vue
+++ b/src/views/Projects.vue
@@ -36,7 +36,7 @@
                     ></v-checkbox>
                   </td>
                   <td class="item-style">
-                    <router-link :to="item.hash" class="project-title">{{ item.projectName }}</router-link>
+                    <router-link :to="item._id" class="project-title">{{ item.projectName }}</router-link>
                   </td>
                   <td class="item-style">
                     <v-chip :color="getColor(item.syntax)" dark>{{ item.syntax }}</v-chip>

--- a/src/views/Projects.vue
+++ b/src/views/Projects.vue
@@ -36,7 +36,7 @@
                     ></v-checkbox>
                   </td>
                   <td class="item-style">
-                    <router-link to="/001" class="project-title">{{ item.projectName }}</router-link>
+                    <router-link :to="item.hash" class="project-title">{{ item.projectName }}</router-link>
                   </td>
                   <td class="item-style">
                     <v-chip :color="getColor(item.syntax)" dark>{{ item.syntax }}</v-chip>

--- a/src/views/Projects.vue
+++ b/src/views/Projects.vue
@@ -9,9 +9,9 @@
         <div class="table-container">
           <v-data-table
             hide-default-header
-            :hide-default-footer="project.length < 7"
+            :hide-default-footer="projects.length < 7"
             :headers="headers"
-            :items="project"
+            :items="projects"
             :items-per-page="7"
             class="project-list-table tableBackground"
           >
@@ -104,7 +104,7 @@
 import IndexToolbar from '../components/IndexToolbar.vue';
 import WelcomeWindow from './WelcomeWindow.vue';
 import { storage } from '../util';
-import { GET_PROJECT, REMOVE_PROJECT } from '../query';
+import { REMOVE_PROJECT } from '../query';
 
 export default {
   name: 'Projects',
@@ -112,9 +112,7 @@ export default {
     IndexToolbar,
     WelcomeWindow,
   },
-  apollo: {
-    project: GET_PROJECT,
-  },
+  props: ['projects'],
   data() {
     return {
       headers: [
@@ -126,7 +124,6 @@ export default {
         { text: 'URL', value: 'hash', sortable: false },
         { text: 'Actions', value: 'actions', sortable: false },
       ],
-      project: [],
       dialog: false,
       sharebox: false,
       userInfo: {
@@ -140,9 +137,6 @@ export default {
   },
   created() {
     this.userID = storage.getUserInfo().userID;
-  },
-  updated() {
-    console.log(this.project);
   },
   methods: {
     triggerDialog(item) {
@@ -159,13 +153,13 @@ export default {
           },
         })
         .then(() => {});
-      const index = this.project.indexOf(item);
-      this.project.splice(index, 1);
+      const index = this.projects.indexOf(item);
+      this.projects.splice(index, 1);
     },
     copyURL(listItemID) {
       const input = document.createElement('input');
       input.value = 'http://cpg.url/';
-      input.value += this.project[listItemID].hash;
+      input.value += this.projects[listItemID].hash;
       document.body.appendChild(input);
       input.select();
       document.execCommand('copy');

--- a/src/views/Projects.vue
+++ b/src/views/Projects.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-row style="height: 88vh" no-gutters>
+  <v-row style="height: 100%" no-gutters>
     <v-col cols="11">
       <WelcomeWindow v-if="!userID" :userInfo="userInfo" @passUserInfo="getUserInfo" />
       <div class="project-list-container">

--- a/src/views/Projects.vue
+++ b/src/views/Projects.vue
@@ -35,7 +35,7 @@
                     ></v-checkbox>
                   </td>
                   <td class="item-style">
-                    <router-link :to="item._id" class="project-title">{{ item.projectName }}</router-link>
+                    <router-link :to="item.hash" class="project-title">{{ item.projectName }}</router-link>
                   </td>
                   <td class="item-style">
                     <v-chip :color="getColor(item.syntax)" dark>{{ item.syntax }}</v-chip>

--- a/src/views/Projects.vue
+++ b/src/views/Projects.vue
@@ -54,14 +54,12 @@
                       "
                       >mdi-share</v-icon
                     >
-                    <!-- <v-icon class="actions-icon" color="white" @click="removeProject(item._id)"> mdi-delete</v-icon> -->
-                    <v-icon class="actions-icon" color="white" @click.stop="triggerDialog(item.projectName, item._id)"
-                      >mdi-delete</v-icon
-                    >
+
+                    <v-icon class="actions-icon" color="white" @click.stop="triggerDialog(item)"> mdi-delete </v-icon>
                     <v-dialog v-model="dialog" width="500" :retain-focus="false">
                       <v-card>
                         <v-card-title class="headline grey lighten-2">
-                          Are you sure to delete {{ itemName }}?
+                          Are you sure to delete {{ selectedItem.projectName }}?
                         </v-card-title>
 
                         <v-divider></v-divider>
@@ -73,7 +71,7 @@
                             text
                             @click="
                               dialog = false;
-                              removeProject(itemID);
+                              removeProject(selectedItem);
                             "
                           >
                             Yes
@@ -136,8 +134,7 @@ export default {
         userAvatar: '',
       },
       storage,
-      itemName: '',
-      itemID: '',
+      selectedItem: '',
       userID: '',
     };
   },
@@ -148,22 +145,22 @@ export default {
     console.log(this.project);
   },
   methods: {
-    triggerDialog(listItemName, listItemID) {
+    triggerDialog(item) {
+      this.selectedItem = item;
       this.dialog = true;
-      this.itemName = listItemName;
-      this.itemID = listItemID;
     },
-    removeProject(listItemID) {
+    removeProject(item) {
       this.$apollo
         .mutate({
           mutation: REMOVE_PROJECT,
           variables: {
-            id: listItemID,
+            /* eslint no-underscore-dangle: ["error", { "allow": ["_id"] }] */
+            id: item._id,
           },
         })
-        .then((res) => {
-          console.log(res);
-        });
+        .then(() => {});
+      const index = this.project.indexOf(item);
+      this.project.splice(index, 1);
     },
     copyURL(listItemID) {
       const input = document.createElement('input');

--- a/src/views/Projects.vue
+++ b/src/views/Projects.vue
@@ -172,7 +172,7 @@ export default {
     },
     copyURL(listItemID) {
       const input = document.createElement('input');
-      input.value = 'http://cpg.url/';
+      input.value = 'https://cpg.url/';
       input.value += this.projects[listItemID].hash;
       document.body.appendChild(input);
       input.select();

--- a/tests/unit/Editor.spec.js
+++ b/tests/unit/Editor.spec.js
@@ -46,9 +46,9 @@ describe('Editor.vue', () => {
 
   it('Render page with editor and console', () => {
     const wrapper = getWrapper();
-    expect.assertions(2);
+    expect.assertions(1);
     expect(wrapper.find('.monaco-editor').isVisible()).toBeTruthy();
-    expect(wrapper.find('.console').isVisible()).toBeTruthy();
+    // expect(wrapper.find('.console').isVisible()).toBeTruthy();
   });
 
   it('Set code and get it in editor', () => {
@@ -57,37 +57,37 @@ describe('Editor.vue', () => {
     expect(wrapper.vm.getCode()).toBe('TEST_CODE');
   });
 
-  it('Run javascript code console.log/info/warn then add log item in log list', () => {
-    const wrapper = getWrapper();
-    wrapper.vm.setCode('console.log("TEST_LOG")');
-    wrapper.vm.runCode();
-    wrapper.vm.setCode('console.info("TEST_INFO_LOG")');
-    wrapper.vm.runCode();
-    wrapper.vm.setCode('console.warn("TEST_WARN_LOG")');
-    wrapper.vm.runCode();
-    expect(wrapper.vm.$data.logList).toMatchObject([
-      { msg: 'TEST_LOG', style: undefined },
-      { msg: 'TEST_INFO_LOG', style: undefined },
-      { msg: 'TEST_WARN_LOG', style: 'warn' },
-    ]);
-  });
+  // it('Run javascript code console.log/info/warn then add log item in log list', () => {
+  //   const wrapper = getWrapper();
+  //   wrapper.vm.setCode('console.log("TEST_LOG")');
+  //   wrapper.vm.runCode();
+  //   wrapper.vm.setCode('console.info("TEST_INFO_LOG")');
+  //   wrapper.vm.runCode();
+  //   wrapper.vm.setCode('console.warn("TEST_WARN_LOG")');
+  //   wrapper.vm.runCode();
+  //   expect(wrapper.vm.$data.logList).toMatchObject([
+  //     { msg: 'TEST_LOG', style: undefined },
+  //     { msg: 'TEST_INFO_LOG', style: undefined },
+  //     { msg: 'TEST_WARN_LOG', style: 'warn' },
+  //   ]);
+  // });
 
-  it('Run javascript error code then add error log item in log list', () => {
-    const wrapper = getWrapper();
-    wrapper.vm.setCode('TEST_ERROR');
-    wrapper.vm.runCode();
-    expect(wrapper.vm.$data.logList[0]).toEqual({ msg: 'ReferenceError: TEST_ERROR is not defined', style: 'error' });
-  });
+  // it('Run javascript error code then add error log item in log list', () => {
+  //   const wrapper = getWrapper();
+  //   wrapper.vm.setCode('TEST_ERROR');
+  //   wrapper.vm.runCode();
+  //   expect(wrapper.vm.$data.logList[0]).toEqual({ msg: 'ReferenceError: TEST_ERROR is not defined', style: 'error' });
+  // });
 
-  it('Clear console then no record in log list', () => {
-    const wrapper = getWrapper();
-    wrapper.vm.setCode('console.log("TEST_LOG")');
-    wrapper.vm.runCode();
-    wrapper.vm.setCode('TEST_ERROR');
-    wrapper.vm.runCode();
-    wrapper.vm.clearConsole();
-    expect(wrapper.vm.$data.logList).toEqual([]);
-  });
+  // it('Clear console then no record in log list', () => {
+  //   const wrapper = getWrapper();
+  //   wrapper.vm.setCode('console.log("TEST_LOG")');
+  //   wrapper.vm.runCode();
+  //   wrapper.vm.setCode('TEST_ERROR');
+  //   wrapper.vm.runCode();
+  //   wrapper.vm.clearConsole();
+  //   expect(wrapper.vm.$data.logList).toEqual([]);
+  // });
 
   it('Receive server code then emit enter room with projectId', (done) => {
     getWrapper();
@@ -126,13 +126,13 @@ describe('Editor.vue', () => {
   });
    */
 
-  it('Change programing language to Go then hide console, change to Javascript and then show console', async () => {
-    const wrapper = getWrapper();
-    const selector = wrapper.find('[test="codeLanguageSelector"]');
-    await selector.setValue('go');
-    expect(wrapper.find('.console').isVisible()).toBe(false);
+  // it('Change programing language to Go then hide console, change to Javascript and then show console', async () => {
+  //   const wrapper = getWrapper();
+  //   const selector = wrapper.find('[test="codeLanguageSelector"]');
+  //   await selector.setValue('go');
+  //   expect(wrapper.find('.console').isVisible()).toBe(false);
 
-    await selector.setValue('javascript');
-    expect(wrapper.find('.console').isVisible()).toBe(true);
-  });
+  //   await selector.setValue('javascript');
+  //   expect(wrapper.find('.console').isVisible()).toBe(true);
+  // });
 });

--- a/tests/unit/Editor.spec.js
+++ b/tests/unit/Editor.spec.js
@@ -48,7 +48,6 @@ describe('Editor.vue', () => {
     const wrapper = getWrapper();
     expect.assertions(1);
     expect(wrapper.find('.monaco-editor').isVisible()).toBeTruthy();
-    // expect(wrapper.find('.console').isVisible()).toBeTruthy();
   });
 
   it('Set code and get it in editor', () => {
@@ -56,38 +55,6 @@ describe('Editor.vue', () => {
     wrapper.vm.setCode('TEST_CODE');
     expect(wrapper.vm.getCode()).toBe('TEST_CODE');
   });
-
-  // it('Run javascript code console.log/info/warn then add log item in log list', () => {
-  //   const wrapper = getWrapper();
-  //   wrapper.vm.setCode('console.log("TEST_LOG")');
-  //   wrapper.vm.runCode();
-  //   wrapper.vm.setCode('console.info("TEST_INFO_LOG")');
-  //   wrapper.vm.runCode();
-  //   wrapper.vm.setCode('console.warn("TEST_WARN_LOG")');
-  //   wrapper.vm.runCode();
-  //   expect(wrapper.vm.$data.logList).toMatchObject([
-  //     { msg: 'TEST_LOG', style: undefined },
-  //     { msg: 'TEST_INFO_LOG', style: undefined },
-  //     { msg: 'TEST_WARN_LOG', style: 'warn' },
-  //   ]);
-  // });
-
-  // it('Run javascript error code then add error log item in log list', () => {
-  //   const wrapper = getWrapper();
-  //   wrapper.vm.setCode('TEST_ERROR');
-  //   wrapper.vm.runCode();
-  //   expect(wrapper.vm.$data.logList[0]).toEqual({ msg: 'ReferenceError: TEST_ERROR is not defined', style: 'error' });
-  // });
-
-  // it('Clear console then no record in log list', () => {
-  //   const wrapper = getWrapper();
-  //   wrapper.vm.setCode('console.log("TEST_LOG")');
-  //   wrapper.vm.runCode();
-  //   wrapper.vm.setCode('TEST_ERROR');
-  //   wrapper.vm.runCode();
-  //   wrapper.vm.clearConsole();
-  //   expect(wrapper.vm.$data.logList).toEqual([]);
-  // });
 
   it('Receive server code then emit enter room with projectId', (done) => {
     getWrapper();
@@ -125,14 +92,4 @@ describe('Editor.vue', () => {
     socket.socketClient.emit('connect');
   });
    */
-
-  // it('Change programing language to Go then hide console, change to Javascript and then show console', async () => {
-  //   const wrapper = getWrapper();
-  //   const selector = wrapper.find('[test="codeLanguageSelector"]');
-  //   await selector.setValue('go');
-  //   expect(wrapper.find('.console').isVisible()).toBe(false);
-
-  //   await selector.setValue('javascript');
-  //   expect(wrapper.find('.console').isVisible()).toBe(true);
-  // });
 });


### PR DESCRIPTION
将读取所有project数据放到了App.vue中并pass到所有children，
project table的create和remove更改的是App.vue中的project数据，可实时显示结果。

在Editor中加入了自定义调节左边section的大小，在没有initEditor()是可以完美实现，但在initEditor()后有瑕疵，需要改进；
EditorHeader的菜单中可显示并连接到其他projects。

每个project的url使用的是project._id，因为isocket中使用的也是id而非hash。这使得project.code可实现实时同步功能，
可是在使用此功能时此project的projectName和syntax会变的不可被读取从而产生bug。

完善了project.vue部分代码使其更简洁。
